### PR TITLE
add in suppport for timing each express route and make the middleware mo...

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -5,8 +5,8 @@ function factory(parentClient) {
     return function (prefix, options) {
         var client = parentClient.getChildClient(prefix);
         options = options || {};
-        var timeByUrl = options.timeByUrl || false
-        var onResponseEnd = options.onResponseEnd
+        var timeByUrl = options.timeByUrl || false;
+        var onResponseEnd = options.onResponseEnd;
 
         return function (req, res, next) {
             var startTime = new Date();


### PR DESCRIPTION
This pull request adds in support for enabling timing request by the express route.

It makes no change to api but uses the undocumented second parameter, an options hash.

metric names are put in the "reponse_time.by_url." bucket. Slashes are replaced with underscores and colons are stripped.

A special exception is made for "/" which is replaced with "root"

I also added a onResponseEnd option which is a function that takes the client, startTime, req and res objects that allows for more custom metrics.

Let me know if you have any issues
