### PR TITLE
Allow ExpressMiddleware without extra prefix

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -3,7 +3,7 @@
  */
 function factory(parentClient) {
     return function (prefix, options) {
-        var client = parentClient.getChildClient(prefix);
+        var client = parentClient.getChildClient(prefix || '');
         options = options || {};
         var timeByUrl = options.timeByUrl || false;
         var onResponseEnd = options.onResponseEnd;


### PR DESCRIPTION
When you have a prefix set up for the global client, the prefix will also applied to the express middleware so when you dont have a need for an extra prefix you get this:
`prefix.undefined.response_time:4|ms`

With this PR it's possible to call the middleware without arguments, so you will get metrics like:
`prefix.response_time:4|ms`

Love,
