### PR TITLE
Make socket creation asynchronous

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -103,7 +103,7 @@ ephemeralSocket.prototype.send = function (data) {
     // If we don't have a socket, or we have created one but it isn't
     // ready yet, we need to enqueue data to send once the socket is ready.
     if (!this._socket || !this._socket_ready) {
-        this.enqueue_data(data);
+        this._enqueue_data(data);
 
         if (!this._socket) {
             this._create_socket();


### PR DESCRIPTION
Fixes issue [#4](https://github.com/msiebuhr/node-statsd-client/issues/4), where a socket is created with `dgram.createSocket()`, but the socket used before it is ready.

This only happens under high load, but that is exactly when you want metrics, and don't want them to cause exceptions to be thrown. :)

To support this, I also added logic to enqueue requests to send data that happen while a socket is not yet ready.

All the tests pass still, but I wasn't sure what else to add to test this. Any suggestions are welcome.
