### PR TITLE
getExpressMiddleware helper: Also report the request method as part of the key

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -18,12 +18,11 @@ function factory(parentClient) {
 
                 client.timing('response_time', startTime);
                 client.increment('response.' + res.statusCode);
-
                 if (timeByUrl && req.route && req.route.path) {
                     var routeName = req.route.path;
                     if (routeName === "/") routeName = "root";
                     // need to get rid of : in route names, remove first /, and replace rest with _
-                    routeName = routeName.replace(/:/g, "").replace(/\//, "").replace(/\//g, "_");
+                    routeName = req.method + '_' + routeName.replace(/:/g, "").replace(/\//, "").replace(/\//g, "_");
                     client.timing('response_time.by_url.' + routeName, startTime);
                 }
 


### PR DESCRIPTION
... when timeByUrl is turned on.

This is helpful for certain REST APIs where different actions are only distinguishable by the http verb.
