### PR TITLE
getExpressMiddleware helper: Avoid calling undefined method

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -20,6 +20,10 @@ function factory(parentClient) {
                 client.increment('response.' + res.statusCode);
                 if (timeByUrl && req.route && req.route.path) {
                     var routeName = req.route.path;
+                    if (Object.prototype.toString.call(routeName) === '[object RegExp]') {
+                        // Might want to do some sanitation here?
+                        routeName = routeName.source;
+                    }
                     if (routeName === "/") routeName = "root";
                     // need to get rid of : in route names, remove first /, and replace rest with _
                     routeName = req.method + '_' + routeName.replace(/:/g, "").replace(/\//, "").replace(/\//g, "_");


### PR DESCRIPTION
... when req.route.name is a RegExp.

Related question -- will the below work as a statsd key?

```
response_time.by_url.GET_^\(?[\w%+@*\-\.\(\)!,]+\_)*
```
