### PR TITLE
fixed issue with orphaned setInterval in EphemeralSocket

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -71,7 +71,10 @@ EphemeralSocket.prototype.close = function () {
     }
 
     // Cancel the running timer
-    clearInterval(this._socketTimer);
+    if (this._socketTimer) {
+        clearInterval(this._socketTimer);
+        this._socketTimer = undefined;
+    }
 
     // Wait a tick or two, so any remaining stats can be sent.
     setTimeout(this.kill.bind(this), 10);
@@ -86,7 +89,10 @@ EphemeralSocket.prototype.kill = function () {
     }
 
     // Clear the timer and catch any further errors silently
-    clearInterval(this._socketTimer);
+    if (this._socketTimer) {
+        clearInterval(this._socketTimer);
+        this._socketTimer = undefined;
+    }
     this._socket.on('error', function () {});
 
     this._socket.close();
@@ -114,7 +120,7 @@ EphemeralSocket.prototype._createSocket = function (callback) {
     this._socket.bind(0, null);
 
     // Start timer, if we have a positive timeout
-    if (this._socketTimeoutMsec > 0) {
+    if (this._socketTimeoutMsec > 0 && !this._socketTimer) {
         this._socketTimer = setInterval(this._socketTimeout.bind(this), this._socketTimeoutMsec);
     }
 };


### PR DESCRIPTION
I noticed issues running sdc in a CLI app, when I called `sdc.close()` the process seemed to hang.

I ran it with timers-debug (https://github.com/tenthbitinc/timers-debug) and noticed that the EphemeralSocket had a orphaned setInterval. It looks like it was just an issue with _createSocket() not checking if there already was an existing timeout set.

```
$ node examples/close-test.js
setTimeout 1
timeoutFired 1
send( statsd-client.test.gauge:77.02251526061445|g )
_enqueue( statsd-client.test.gauge:77.02251526061445|g )
setInterval 2
send( statsd-client.test.counter:1|c )
_enqueue( statsd-client.test.counter:1|c )
send( statsd-client.test.counter:1|c )
_enqueue( statsd-client.test.counter:1|c )
send( statsd-client.speed:59|ms )
_enqueue( statsd-client.speed:59|ms )
close()
setTimeout 3
_socketTimeout()
_flushBuffer() → statsd-client.test.gauge:77.02251526061445|g
statsd-client.test.counter:1|c
statsd-client.test.counter:1|c
statsd-client.speed:59|ms
_send( statsd-client.test.gauge:77.02251526061445|g
statsd-client.test.counter:1|c
statsd-client.test.counter:1|c
statsd-client.speed:59|ms )
_createSocket()
setInterval 4
_createSocket setInterval { ontimeout: [Function], debugUniqueID: 4 }
statsd-client.test.gauge:77.02251526061445|g
statsd-client.test.counter:1|c
statsd-client.test.counter:1|c
statsd-client.speed:59|ms
_socketTimeout()
_socketTimeout()
close()
clearInterval 4
setTimeout 5
timeoutFired 5
kill()
_socketTimeout()
_socketTimeout()
_socketTimeout()
_socketTimeout()
timeoutFired 3
active timer #Error
    at TimersDebug.uniqueIDForTimer (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:95:19)
    at TimersDebug.setInterval (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:73:25)
    at EphemeralSocket._enqueue (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/EphemeralSocket.js:136:29)
    at EphemeralSocket.send (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/EphemeralSocket.js:163:14)
    at StatsDClient.gauge (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/statsd-client.js:41:27)
    at /Users/ddaniels/Dropbox/code/github/node-statsd-client/examples/close-test.js:15:13
    at null._onTimeout (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:57:9)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15) Error
    at TimersDebug.uniqueIDForTimer (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:95:19)
    at TimersDebug.setInterval (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:73:25)
    at EphemeralSocket._enqueue (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/EphemeralSocket.js:136:29)
    at EphemeralSocket.send (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/EphemeralSocket.js:163:14)
    at StatsDClient.gauge (/Users/ddaniels/Dropbox/code/github/node-statsd-client/lib/statsd-client.js:41:27)
    at /Users/ddaniels/Dropbox/code/github/node-statsd-client/examples/close-test.js:15:13
    at null._onTimeout (/Users/ddaniels/Dropbox/code/github/node-statsd-client/node_modules/timers-debug/timers-debug.js:57:9)
    at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
_socketTimeout()
_socketTimeout()
```
