### PR TITLE
add count-by-url to express helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ app.listen(3000);
 This will count responses by status-code (`prefix.<statuscode>`) and the
 overall response-times.
 
-It can also measure per-URL (e.g. PUT to `/:user/:thing` will become
-`PUT_user_thing` by setting the `timeByUrl: true` in the `options`-object:
+It can also measure per-URL timings and counts (e.g. PUT to `/:user/:thing`
+will become `PUT_user_thing` by setting the `timeByUrl: true` and
+`countByUrl: true` in the `options`-object:
 
 ```javascript
 app.use(sdc.helpers.getExpressMiddleware('prefix', { timeByUrl: true }));

--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -14,6 +14,7 @@ function factory(parentClient) {
         var client = parentClient.getChildClient(prefix || '');
         options = options || {};
         var timeByUrl = options.timeByUrl || false;
+        var countByUrl = options.countByUrl || false;
         var onResponseEnd = options.onResponseEnd;
 
         return function (req, res, next) {
@@ -27,7 +28,7 @@ function factory(parentClient) {
                 client.increment('response_code.' + res.statusCode);
 
                 // Time by URL?
-                if (timeByUrl) {
+                if (timeByUrl || countByUrl) {
                     var routeName = "unknown_express_route";
 
                     // Did we get a harc-coded name, or should we figure one out?
@@ -46,7 +47,12 @@ function factory(parentClient) {
                     // Get rid of : in route names, remove first and last /,
                     // and replace rest with _.
                     routeName = 'response_time.' + routeName.replace(/:/g, "").replace(/^\/|\/$/g, "").replace(/\//g, "_");
-                    client.timing(routeName, startTime);
+                    if (timeByUrl) {
+                      client.timing(routeName, startTime);
+                    }
+                    if (countByUrl) {
+                      client.increment(routeName);
+                    }
                 } else {
                     client.timing('response_time', startTime);
                 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,4 @@
 var StatsDClient = require('../lib/statsd-client'),
-    EventEmitter = require('events').EventEmitter,
     assert = require('chai').assert;
 
 /*global describe before it*/


### PR DESCRIPTION
This adds an option to collect counts by url for each route, similar to the timeByUrl feature.
