### PR TITLE
convert EphemeralSocket._port explicit to integer

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -6,7 +6,7 @@ function EphemeralSocket(options) {
     options = options || {};
 
     this._hostname = options.host || 'localhost';
-    this._port = options.port || 8125;
+    this._port = parseInt(options.port, 10) || 8125;
     this._debug = options.debug || false;
     this._socketTimeoutMsec = 'socketTimeout' in options ? options.socketTimeout : 1000;
 

--- a/test/EphemeralSocket.js
+++ b/test/EphemeralSocket.js
@@ -31,6 +31,12 @@ describe('EphemeralSocket', function () {
         }, 25);
     });
 
+
+    it("Convert the port to integer", function () {
+        var testSocket = new EphemeralSocket({port: "1234"});
+        assert.strictEqual(testSocket._port, 1234);
+    });
+
     it("Sends data immediately with maxBufferSize = 0", function (done) {
         var withoutBuffer = new EphemeralSocket({maxBufferSize: 0}),
             start = Date.now();


### PR DESCRIPTION
Hi msiebuhr,

the reason for my fix was that my port configuration came from an environment variable.
I think it makes the client more robust with an explicit conversion of the port.

What do you think? 

Best regards
FQ400
