### PR TITLE
EphemeralSocket should be exclusive

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -117,7 +117,7 @@ EphemeralSocket.prototype._createSocket = function (callback) {
     this._socket.once('listening', function () {
         return callback();
     });
-    this._socket.bind(0, null);
+    this._socket.bind({ port: 0, exclusive: true }, null);
 
     // Start timer, if we have a positive timeout
     if (this._socketTimeoutMsec > 0 && !this._socketTimer) {


### PR DESCRIPTION
It's a client UDP socket so in cluster mode it should be exclusive rather than shared (which causes various `AssertionError: false == true`s in iojs / node > 0.10)

Similar reasoning to https://github.com/joyent/node/pull/8643