### PR TITLE
Chainable API

### DIFF
--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -49,11 +49,15 @@ StatsDClient.prototype.getChildClient = function (extraPrefix) {
  */
 StatsDClient.prototype.gauge = function (name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|g");
+
+    return this;
 };
 
 StatsDClient.prototype.gaugeDelta = function (name, delta) {
     var sign = delta >= 0 ? "+" : "-";
     this._socket.send(this.options.prefix + name + ":" + sign + Math.abs(delta) + "|g");
+
+    return this;
 };
 
 /*
@@ -61,6 +65,8 @@ StatsDClient.prototype.gaugeDelta = function (name, delta) {
  */
 StatsDClient.prototype.set = function (name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|s");
+
+    return this;
 };
 
 /*
@@ -68,6 +74,8 @@ StatsDClient.prototype.set = function (name, value) {
  */
 StatsDClient.prototype.counter = function (name, delta) {
     this._socket.send(this.options.prefix + name + ":" + delta + "|c");
+
+    return this;
 };
 
 /*
@@ -75,6 +83,8 @@ StatsDClient.prototype.counter = function (name, delta) {
  */
 StatsDClient.prototype.increment = function (name, delta) {
     this.counter(name, Math.abs(delta || 1));
+
+    return this;
 };
 
 /*
@@ -82,6 +92,8 @@ StatsDClient.prototype.increment = function (name, delta) {
  */
 StatsDClient.prototype.decrement = function (name, delta) {
     this.counter(name, -1 * Math.abs(delta || 1));
+
+    return this;
 };
 
 /*
@@ -92,6 +104,8 @@ StatsDClient.prototype.timing = function (name, time) {
     var t = time instanceof Date ? new Date() - time : time;
 
     this._socket.send(this.options.prefix + name + ":" + t + "|ms");
+
+    return this;
 };
 
 /*
@@ -99,6 +113,8 @@ StatsDClient.prototype.timing = function (name, time) {
  */
 StatsDClient.prototype.histogram = function (name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|h");
+
+    return this;
 };
 
 /*
@@ -106,6 +122,8 @@ StatsDClient.prototype.histogram = function (name, value) {
  */
 StatsDClient.prototype.close = function () {
     this._socket.close();
+
+    return this;
 };
 
 /*

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -121,6 +121,44 @@ describe('StatsDClient', function () {
             }, 20);
         });
     });
+
+    describe('Chaining', function() {
+      it('.gauge() chains', function() {
+        assert.equal(c, c.gauge('x', 'y'));
+      });
+
+      it('.gaugeDelta() chains', function() {
+        assert.equal(c, c.gaugeDelta('x', 'y'));
+      });
+
+      it('.set() chains', function() {
+        assert.equal(c, c.set('x', 'y'));
+      });
+
+      it('.counter() chains', function() {
+        assert.equal(c, c.counter('x', 'y'));
+      });
+
+      it('.increment() chains', function() {
+        assert.equal(c, c.increment('x', 'y'));
+      });
+
+      it('.decrement() chains', function() {
+        assert.equal(c, c.decrement('x', 'y'));
+      });
+
+      it('.timing() chains', function() {
+        assert.equal(c, c.timing('x', 'y'));
+      });
+
+      it('.histogram() chains', function() {
+        assert.equal(c, c.histogram('x', 'y'));
+      });
+
+      it('.close() chains', function() {
+        assert.equal(c, c.close('x', 'y'));
+      });
+    });
 });
 
 describe('StatsDClient / HTTP', function () {


### PR DESCRIPTION
Basic logging methods are now chainable, e.g.:

```javascript
statsd.increment('abc', 1).timing('xyz', 1000);
```