### PR TITLE
[Update] Add dns cache in udp mode to ease the pressure of dns server.

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -1,4 +1,5 @@
 var dgram = require('dgram');
+var resolve = require('./helpers/resolve');
 
 /*global console*/
 
@@ -6,6 +7,7 @@ function EphemeralSocket(options) {
     options = options || {};
 
     this._hostname = options.host || 'localhost';
+    this._ip = null;
     this._port = parseInt(options.port, 10) || 8125;
     this._debug = options.debug || false;
     this._socketTimeoutMsec = 'socketTimeout' in options ? options.socketTimeout : 1000;
@@ -181,7 +183,18 @@ EphemeralSocket.prototype._send = function (data) {
             console.warn(message.toString());
         }
 
-        that._socket.send(message, 0, message.length, that._port, that._hostname);
+        if (that._ip) {
+            that._socket.send(message, 0, message.length, that._port, that._ip);
+        } else {
+            resolve(that._hostname, function (err, ip) {
+                if (err) {
+                    throw err;
+                } else {
+                    that._ip = ip;
+                    that._socket.send(message, 0, message.length, that._port, that._ip);
+                }
+            });
+        }
     });
 };
 

--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -1,4 +1,5 @@
 var dgram = require('dgram');
+var dns = require('dns');
 var resolve = require('./helpers/resolve');
 
 /*global console*/
@@ -186,7 +187,11 @@ EphemeralSocket.prototype._send = function (data) {
         if (that._ip) {
             that._socket.send(message, 0, message.length, that._port, that._ip);
         } else {
-            resolve(that._hostname, function (err, ip) {
+            resolve(that._hostname, {
+                family: 4,
+                hints: dns.ADDRCONFIG | dns.V4MAPPED,
+                all: false
+            }, function (err, ip) {
                 if (err) {
                     throw err;
                 } else {

--- a/lib/helpers/resolve.js
+++ b/lib/helpers/resolve.js
@@ -1,0 +1,28 @@
+/**
+ * Ease the pressure of dns,
+ * resolve ip address firstly.
+ */
+
+var dns = require('dns');
+
+/**
+ * Resolve ip address from hostname.
+ * @public
+ * @param  {string}   hostname Hostname
+ * @param  {object}   options  dns.lookup options
+ * @param  {Function} callback Callback function
+ */
+var resolve = function (hostname, options, callback) {
+    dns.lookup(hostname, {
+        family: 4,
+        hints: dns.ADDRCONFIG | dns.V4MAPPED,
+        all: false
+    }, function (err, ip) {
+        if (err) {
+            return callback(err);
+        }
+        return callback(null, ip);
+    });
+};
+
+module.exports = resolve;

--- a/lib/helpers/resolve.js
+++ b/lib/helpers/resolve.js
@@ -13,11 +13,7 @@ var dns = require('dns');
  * @param  {Function} callback Callback function
  */
 var resolve = function (hostname, options, callback) {
-    dns.lookup(hostname, {
-        family: 4,
-        hints: dns.ADDRCONFIG | dns.V4MAPPED,
-        all: false
-    }, function (err, ip) {
+    dns.lookup(hostname, options, function (err, ip) {
         if (err) {
             return callback(err);
         }

--- a/test/TestResolve.js
+++ b/test/TestResolve.js
@@ -1,0 +1,16 @@
+var dns = require('dns'),
+    assert = require('chai').assert,
+    resolve = require('../lib/helpers/resolve');
+
+describe('Test resolve', function () {
+    it('should be ok', function (done) {
+        dns.lookup('localhost', {
+            family: 4,
+            hints: dns.ADDRCONFIG | dns.V4MAPPED,
+            all: false
+        }, function (err, ip) {
+            assert.equal(ip, '127.0.0.1');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
When using udp mode, the client will resolve ip address from dns server per request. It brings great pressure for my dns server. So I change the code, when using udp mode, resolve the ip address firstly.