### PR TITLE
Add express middleware support for sub-routers

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -19,7 +19,9 @@ function findRouteName(req, res) {
             routeName = routeName.source;
         }
 
-        if (routeName === '/') {
+        if (req.baseUrl) {
+            routeName = req.baseUrl + routeName;
+        } else if (routeName === '/') {
             routeName = 'root';
         }
 

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "~1.3.0",
+    "express": "^4.13.4",
     "jshint": "~0.9.1",
-    "mocha": "~1.6.0"
+    "mocha": "~1.6.0",
+    "sinon": "^1.17.3",
+    "supertest": "^1.2.0"
   },
   "scripts": {
     "test": "mocha -R spec; jshint lib/ test/"

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,14 +1,67 @@
 var StatsDClient = require('../lib/statsd-client'),
+    FakeServer = require('./FakeServer'),
     EventEmitter = require('events').EventEmitter,
-    assert = require('chai').assert;
+    assert = require('chai').assert,
+    express = require('express'),
+    supertest = require('supertest'),
+    sinon = require('sinon');
 
 /*global describe before it*/
 
 describe('Helpers', function () {
     var c;
+    var s;
+    var es;
+    var baseUrl;
 
-    before(function () {
-        c = new StatsDClient();
+    before(function (done) {
+        s = new FakeServer();
+        c = new StatsDClient({
+            maxBufferSize: 0
+        });
+
+        var app = express();
+
+        app.use(c.helpers.getExpressMiddleware('express', { timeByUrl: true }));
+
+        // Routes defined on the express app itself.
+        app.get('/', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        app.get('/foo', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        app.post('/foo', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        app.get('/foo/:param/bar', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        // Routes defined on the a subrouter or "micro-app".
+        var router = express.Router();
+
+        router.get('/foo', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        app.use('/subrouter', router);
+
+        es = app.listen(3000, function () {
+            baseUrl = 'http://localhost:' + 3000;
+            s.start(done);
+        });
+    });
+
+    after(function (done) {
+      es.on('close', function () {
+        s.stop();
+        done();
+      });
+      es.close();
     });
 
     it('.helpers is an object', function () {
@@ -19,5 +72,83 @@ describe('Helpers', function () {
         var f = c.helpers.getExpressMiddleware('prefix');
         assert.isFunction(f);
         assert.lengthOf(f, 3);
+    });
+
+    describe('response times', function () {
+      var sandbox;
+      beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+        sandbox.useFakeTimers(new Date().valueOf(), 'Date');
+      });
+
+      afterEach(function () {
+        sandbox.restore();
+      });
+
+      describe('GET', function () {
+        it('should count the response code', function (done) {
+          supertest(baseUrl)
+            .get('/')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err);
+              s.expectMessage('express.response_code.200:1|c', done);
+            });
+        });
+
+        it('/ → "GET_root"', function (done) {
+          supertest(baseUrl)
+            .get('/')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err);
+              s.expectMessage('express.response_time.GET_root:0|ms', done);
+            });
+        });
+
+        it('/foo → "GET_foo"', function (done) {
+          supertest(baseUrl)
+            .get('/foo')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err);
+              s.expectMessage('express.response_time.GET_foo:0|ms', done);
+            });
+        });
+
+        it('/foo/:param/bar → "GET_foo_param_bar"', function (done) {
+          supertest(baseUrl)
+            .get('/foo/mydynamicparameter/bar')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err);
+              s.expectMessage('express.response_time.GET_foo_param_bar:0|ms', done);
+            });
+        });
+
+        describe('sub-router', function () {
+          it('/subrouter/foo → "GET_subrouter_foo"', function (done) {
+            supertest(baseUrl)
+              .get('/subrouter/foo')
+              .expect(200)
+              .end(function (err, res) {
+                if (err) return done(err);
+                s.expectMessage('express.response_time.GET_subrouter_foo:0|ms', done);
+              });
+          });
+        });
+      });
+
+      describe('POST', function () {
+        it('/foo → "POST_foo"', function (done) {
+          supertest(baseUrl)
+          .post('/foo')
+          .expect(200)
+          .end(function (err, res) {
+            if (err) return done(err);
+            s.expectMessage('express.response_time.POST_foo:0|ms', done);
+          });
+        });
+      });
     });
 });


### PR DESCRIPTION
This PR pre-pends `req.baseUrl` to the default StatsD key for the express middleware when `timeByUrl` is true. This allows express "mini-applications" and makes sure that the url "/subrouter/foo" and
"/foo" get distinct StatsD keys when "/subrouter" is an express "mini-application".

Changes:
- Add req.baseUrl to express middleware StatsD key.
- Add express tests.

Express documentation: http://expressjs.com/en/4x/api.html#router