### PR TITLE
accept 0 as parameter for increment/decrement

### DIFF
--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -82,7 +82,7 @@ StatsDClient.prototype.counter = function (name, delta) {
  * increment(name, [delta=1])
  */
 StatsDClient.prototype.increment = function (name, delta) {
-    this.counter(name, Math.abs(undefined === delta ? 1 : delta));
+    this.counter(name, Math.abs(delta === undefined ? 1 : delta));
 
     return this;
 };
@@ -91,7 +91,7 @@ StatsDClient.prototype.increment = function (name, delta) {
  * decrement(name, [delta=-1])
  */
 StatsDClient.prototype.decrement = function (name, delta) {
-    this.counter(name, -1 * Math.abs(undefined === delta ? 1 : delta));
+    this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta));
 
     return this;
 };

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -82,7 +82,7 @@ StatsDClient.prototype.counter = function (name, delta) {
  * increment(name, [delta=1])
  */
 StatsDClient.prototype.increment = function (name, delta) {
-    this.counter(name, Math.abs(delta || 1));
+    this.counter(name, Math.abs(undefined === delta ? 1 : delta));
 
     return this;
 };
@@ -91,7 +91,7 @@ StatsDClient.prototype.increment = function (name, delta) {
  * decrement(name, [delta=-1])
  */
 StatsDClient.prototype.decrement = function (name, delta) {
-    this.counter(name, -1 * Math.abs(delta || 1));
+    this.counter(name, -1 * Math.abs(undefined === delta ? 1 : delta));
 
     return this;
 };

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -61,6 +61,16 @@ describe('StatsDClient', function () {
             c.decrement('abc', -3);
             s.expectMessage('abc:-3|c', done);
         });
+
+        it('.counter("abc", 0) → "abc:0|c', function (done) {
+            c.counter('abc', 0);
+            s.expectMessage('abc:0|c', done);
+        });
+
+        it('.decrement("abc", 0) → "abc:0|c', function (done) {
+            c.decrement('abc', 0);
+            s.expectMessage('abc:0|c', done);
+        });
     });
 
     describe('Gauges', function () {


### PR DESCRIPTION
do not change 0 to 1 when using increment/decrement.
even if incrementing/decrementing by 0 is useless, statsd-client shouldn't send 1 when we explicitely give 0 as a parameter.