### PR TITLE
Pass HTTP headers as documented

### DIFF
--- a/lib/HttpSocket.js
+++ b/lib/HttpSocket.js
@@ -8,7 +8,7 @@ function HttpSocket(options) {
 
     this._requestOptions = urlParse(options.host || 'http://localhost/');
     this._requestOptions.method = 'PUT';
-    this._requestOptions.heders = options.headers || {};
+    this._requestOptions.headers = options.headers || {};
     this._debug = options.debug || false;
     this._socketTimeoutMsec = 'socketTimeout' in options ? options.socketTimeout : 1000;
 


### PR DESCRIPTION
G'day! I noticed the `headers` option for `HttpSocket` couldn't possibly work, and fixed it.