### PR TITLE
Fix bug in how res.end is handled

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -56,6 +56,7 @@ function factory(parentClient) {
             // Shadow end request
             var end = res.end;
             res.end = function () {
+                res.end = end;
                 end.apply(res, arguments);
 
                 var urlPrefix = '';


### PR DESCRIPTION
Hello,

sometimes res.end is getting called twice (depending on the output data format). This means that your code is also called twice.

setting res.end back to its original value will prevent your shadow end request from being called twice.