### PR TITLE
Replace anonymous functions with named functions

### DIFF
--- a/lib/EphemeralSocket.js
+++ b/lib/EphemeralSocket.js
@@ -20,7 +20,7 @@ function EphemeralSocket(options) {
     this._buffer = "";
 }
 
-EphemeralSocket.prototype.log = function (messages) {
+EphemeralSocket.prototype.log = function log(messages) {
     //console.log.apply(null, arguments);
 };
 
@@ -33,7 +33,7 @@ EphemeralSocket.prototype.log = function (messages) {
  * If there is nothing in the buffer and the socket hasn't been used in the
  * previous interval, close it.
  */
-EphemeralSocket.prototype._socketTimeout = function () {
+EphemeralSocket.prototype._socketTimeout = function _socketTimeout() {
     this.log("close()");
     // Flush the buffer, if it contain anything.
     if (this._buffer.length > 0) {
@@ -60,7 +60,7 @@ EphemeralSocket.prototype._socketTimeout = function () {
 /*
  * Close the socket, if in use and cancel the interval-check, if running.
  */
-EphemeralSocket.prototype.close = function () {
+EphemeralSocket.prototype.close = function close() {
     this.log("close()");
     if (!this._socket) {
         return;
@@ -82,7 +82,7 @@ EphemeralSocket.prototype.close = function () {
 
 /* Kill the socket RIGHT NOW.
  */
-EphemeralSocket.prototype.kill = function () {
+EphemeralSocket.prototype.kill = function kill() {
     this.log("kill()");
     if (!this._socket) {
         return;
@@ -99,7 +99,7 @@ EphemeralSocket.prototype.kill = function () {
     this._socket = undefined;
 };
 
-EphemeralSocket.prototype._createSocket = function (callback) {
+EphemeralSocket.prototype._createSocket = function _createSocket(callback) {
     this.log("_createSocket()");
     var that = this;
     if (this._socket) {
@@ -127,7 +127,7 @@ EphemeralSocket.prototype._createSocket = function (callback) {
 
 /* Buffer management
  */
-EphemeralSocket.prototype._enqueue = function (data) {
+EphemeralSocket.prototype._enqueue = function _enqueue(data) {
     this.log("_enqueue(", data, ")");
 
     if (!this._socketTimer) {
@@ -145,7 +145,7 @@ EphemeralSocket.prototype._enqueue = function (data) {
     }
 };
 
-EphemeralSocket.prototype._flushBuffer = function () {
+EphemeralSocket.prototype._flushBuffer = function _flushBuffer() {
     this.log("_flushBuffer() →", this._buffer);
     this._send(this._buffer);
     this._buffer = "";
@@ -153,7 +153,7 @@ EphemeralSocket.prototype._flushBuffer = function () {
 
 /* Send data - public interface.
  */
-EphemeralSocket.prototype.send = function (data) {
+EphemeralSocket.prototype.send = function send(data) {
     this.log("send(", data, ")");
     if (this._maxBufferSize === 0) {
         return this._send(data);
@@ -165,7 +165,7 @@ EphemeralSocket.prototype.send = function (data) {
 /*
  * Send data.
  */
-EphemeralSocket.prototype._send = function (data) {
+EphemeralSocket.prototype._send = function _send(data) {
     this.log("_send(", data, ")");
     // If we don't have a socket, or we have created one but it isn't
     // ready yet, we need to enqueue data to send once the socket is ready.

--- a/lib/HttpSocket.js
+++ b/lib/HttpSocket.js
@@ -24,14 +24,14 @@ function HttpSocket(options) {
     this._buffer = "";
 }
 
-HttpSocket.prototype.log = function (messages) {
+HttpSocket.prototype.log = function log(messages) {
     //console.log.apply(null, arguments);
 };
 
 /* Checks if there is anything in it's buffer that need to be sent. If it is
  * non-empty, it will be flushed.
  */
-HttpSocket.prototype._socketTimeout = function () {
+HttpSocket.prototype._socketTimeout = function _socketTimeout() {
     this.log("_socketTimeout()");
     // Flush the buffer, if it contain anything.
     if (this._buffer.length > 0) {
@@ -44,7 +44,7 @@ HttpSocket.prototype._socketTimeout = function () {
 /*
  * Flush all current data and stop any timers running.
  */
-HttpSocket.prototype.close = function () {
+HttpSocket.prototype.close = function close() {
     this.log("close()");
     if (this._buffer.length > 0) {
         this._flushBuffer();
@@ -62,7 +62,7 @@ HttpSocket.prototype.close = function () {
 
 /* Kill the socket RIGHT NOW.
  */
-HttpSocket.prototype.kill = function () {
+HttpSocket.prototype.kill = function kill() {
     this.log("kill()");
 
     // Clear the timer and catch any further errors silently
@@ -74,7 +74,7 @@ HttpSocket.prototype.kill = function () {
 
 /* Buffer management
  */
-HttpSocket.prototype._enqueue = function (data) {
+HttpSocket.prototype._enqueue = function _enqueue(data) {
     this.log("_enqueue(", data, ")");
 
     if (!this._socketTimer) {
@@ -93,7 +93,7 @@ HttpSocket.prototype._enqueue = function (data) {
     }
 };
 
-HttpSocket.prototype._flushBuffer = function () {
+HttpSocket.prototype._flushBuffer = function _flushBuffer() {
     this.log("_flushBuffer() →", this._buffer);
     this._send(this._buffer);
     this._buffer = "";
@@ -101,7 +101,7 @@ HttpSocket.prototype._flushBuffer = function () {
 
 /* Send data - public interface.
  */
-HttpSocket.prototype.send = function (data) {
+HttpSocket.prototype.send = function send(data) {
     this.log("send(", data, ")");
     if (this._maxBufferSize === 0) {
         return this._send(data);
@@ -113,7 +113,7 @@ HttpSocket.prototype.send = function (data) {
 /*
  * Send data.
  */
-HttpSocket.prototype._send = function (data) {
+HttpSocket.prototype._send = function _send(data) {
     this.log("_send(", data, ")");
     var that = this;
 

--- a/lib/TCPSocket.js
+++ b/lib/TCPSocket.js
@@ -22,7 +22,7 @@ function TCPSocket(options) {
     this._buffer = [];
 }
 
-TCPSocket.prototype.log = function (messages) {
+TCPSocket.prototype.log = function log(messages) {
     //console.log.apply(null, arguments);
 };
 
@@ -35,7 +35,7 @@ TCPSocket.prototype.log = function (messages) {
  * If there is nothing in the buffer and the socket hasn't been used in the
  * previous interval, close it.
  */
-TCPSocket.prototype._socketTimeout = function () {
+TCPSocket.prototype._socketTimeout = function _socketTimeout() {
     this.log("close()");
     // Flush the buffer, if it contain anything.
     if (this._buffer.length > 0) {
@@ -72,7 +72,7 @@ TCPSocket.prototype._socketTimeout = function () {
 /*
  * Close the socket, if in use and cancel the interval-check, if running.
  */
-TCPSocket.prototype.close = function () {
+TCPSocket.prototype.close = function close() {
     this.log("close()");
     if (!this._socket) {
         return;
@@ -94,7 +94,7 @@ TCPSocket.prototype.close = function () {
 
 /* Kill the socket RIGHT NOW.
  */
-TCPSocket.prototype.kill = function () {
+TCPSocket.prototype.kill = function kill() {
     this.log("kill()");
     if (!this._socket) {
         return;
@@ -111,7 +111,7 @@ TCPSocket.prototype.kill = function () {
     this._socket = undefined;
 };
 
-TCPSocket.prototype._createSocket = function (callback) {
+TCPSocket.prototype._createSocket = function _createSocket(callback) {
     this.log("_createSocket()");
     var that = this;
     if (this._socket) {
@@ -141,7 +141,7 @@ TCPSocket.prototype._createSocket = function (callback) {
 
 /* Buffer management
  */
-TCPSocket.prototype._enqueue = function (data) {
+TCPSocket.prototype._enqueue = function _enqueue(data) {
     this.log("_enqueue(", data, ")");
 
     if (!this._socketTimer) {
@@ -155,7 +155,7 @@ TCPSocket.prototype._enqueue = function (data) {
     this._buffer.push(data);
 };
 
-TCPSocket.prototype._flushBuffer = function () {
+TCPSocket.prototype._flushBuffer = function _flushBuffer() {
     this.log("_flushBuffer() →", this._buffer);
     var that = this;
     this._send(this._buffer, function() {
@@ -165,7 +165,7 @@ TCPSocket.prototype._flushBuffer = function () {
 
 /* Send data - public interface.
  */
-TCPSocket.prototype.send = function (data) {
+TCPSocket.prototype.send = function send(data) {
     this.log("send(", data, ")");
     if (this._maxBufferSize === 0) {
         return this._send([data], function() {});
@@ -177,7 +177,7 @@ TCPSocket.prototype.send = function (data) {
 /*
  * Send data.
  */
-TCPSocket.prototype._send = function (data, callback) {
+TCPSocket.prototype._send = function _send(data, callback) {
     this.log("_send(", data, ")");
     // If we don't have a socket, or we have created one but it isn't
     // ready yet, we need to enqueue data to send once the socket is ready.
@@ -187,7 +187,7 @@ TCPSocket.prototype._send = function (data, callback) {
     this._createSocket(that._writeToSocket.bind(that, data, callback));
 };
 
-TCPSocket.prototype._writeToSocket = function (data, callback) {
+TCPSocket.prototype._writeToSocket = function _writeToSocket(data, callback) {
     // Create message
     // Trailing \n important because socket.write will sometimes concat multiple 'write' calls.
     var message = new Buffer(data.join('\n') + '\n');

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -37,7 +37,7 @@ function StatsDClient(options) {
 /*
  * Get a "child" client with a sub-prefix.
  */
-StatsDClient.prototype.getChildClient = function (extraPrefix) {
+StatsDClient.prototype.getChildClient = function getChildClient(extraPrefix) {
     return new StatsDClient({
         prefix: this.options.prefix + extraPrefix,
         _socket: this._socket
@@ -47,13 +47,13 @@ StatsDClient.prototype.getChildClient = function (extraPrefix) {
 /*
  * gauge(name, value)
  */
-StatsDClient.prototype.gauge = function (name, value) {
+StatsDClient.prototype.gauge = function gauge(name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|g");
 
     return this;
 };
 
-StatsDClient.prototype.gaugeDelta = function (name, delta) {
+StatsDClient.prototype.gaugeDelta = function gaugeDelta(name, delta) {
     var sign = delta >= 0 ? "+" : "-";
     this._socket.send(this.options.prefix + name + ":" + sign + Math.abs(delta) + "|g");
 
@@ -63,7 +63,7 @@ StatsDClient.prototype.gaugeDelta = function (name, delta) {
 /*
  * set(name, value)
  */
-StatsDClient.prototype.set = function (name, value) {
+StatsDClient.prototype.set = function set(name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|s");
 
     return this;
@@ -72,7 +72,7 @@ StatsDClient.prototype.set = function (name, value) {
 /*
  * counter(name, delta)
  */
-StatsDClient.prototype.counter = function (name, delta) {
+StatsDClient.prototype.counter = function counter(name, delta) {
     this._socket.send(this.options.prefix + name + ":" + delta + "|c");
 
     return this;
@@ -81,7 +81,7 @@ StatsDClient.prototype.counter = function (name, delta) {
 /*
  * increment(name, [delta=1])
  */
-StatsDClient.prototype.increment = function (name, delta) {
+StatsDClient.prototype.increment = function increment(name, delta) {
     this.counter(name, Math.abs(delta === undefined ? 1 : delta));
 
     return this;
@@ -90,7 +90,7 @@ StatsDClient.prototype.increment = function (name, delta) {
 /*
  * decrement(name, [delta=-1])
  */
-StatsDClient.prototype.decrement = function (name, delta) {
+StatsDClient.prototype.decrement = function decrement(name, delta) {
     this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta));
 
     return this;
@@ -99,7 +99,7 @@ StatsDClient.prototype.decrement = function (name, delta) {
 /*
  * timing(name, date-object | ms)
  */
-StatsDClient.prototype.timing = function (name, time) {
+StatsDClient.prototype.timing = function timing(name, time) {
     // Date-object or integer?
     var t = time instanceof Date ? new Date() - time : time;
 
@@ -111,7 +111,7 @@ StatsDClient.prototype.timing = function (name, time) {
 /*
  * histogram(name, value)
  */
-StatsDClient.prototype.histogram = function (name, value) {
+StatsDClient.prototype.histogram = function histogram(name, value) {
     this._socket.send(this.options.prefix + name + ":" + value + "|h");
 
     return this;
@@ -121,8 +121,8 @@ StatsDClient.prototype.histogram = function (name, value) {
  * Send raw data to the underlying socket. Useful for dealing with custom
  * statsd-extensions in a pinch.
  */
-StatsDClient.prototype.raw = function (raw) {
-    this._socket.send(raw);
+StatsDClient.prototype.raw = function raw(rawData) {
+    this._socket.send(rawData);
 
     return this;
 };
@@ -130,7 +130,7 @@ StatsDClient.prototype.raw = function (raw) {
 /*
  * Close the socket, if in use and cancel the interval-check, if running.
  */
-StatsDClient.prototype.close = function () {
+StatsDClient.prototype.close = function close() {
     this._socket.close();
 
     return this;


### PR DESCRIPTION
Hello.

I propose to replace anonymous functions with named (function expressions become function expression + declaration). Generally it's a good practice to use named functions because they provide more detailed stacktraces and they help in debugging and in profiling (it's a lot easier to find out functions by name during cpu profiling).

Also it will add `.name` property which can be used, for example, in `Proxy`'s apply methods which is useful if you're writing some kind of wrappers around this library.