### PR TITLE
Enable express middleware to send both url prefixed and non prefixed status code increments

### DIFF
--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -68,7 +68,7 @@ function factory(parentClient) {
                     client.increment('response_code' + urlPrefix + '.' + res.statusCode);
                 }
 
-                client.increment('response_code.' + res.statusCode)
+                client.increment('response_code.' + res.statusCode);
                 client.timing('response_time' + urlPrefix, startTime);
 
                 if (onResponseEnd) {

--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -65,9 +65,10 @@ function factory(parentClient) {
                 if (timeByUrl) {
                     urlPrefix += '.';
                     urlPrefix += findRouteName(req, res) || notFoundRouteName;
+                    client.increment('response_code' + urlPrefix + '.' + res.statusCode);
                 }
 
-                client.increment('response_code' + urlPrefix + '.' + res.statusCode);
+                client.increment('response_code.' + res.statusCode)
                 client.timing('response_time' + urlPrefix, startTime);
 
                 if (onResponseEnd) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -92,9 +92,19 @@ describe('Helpers', function () {
             .expect(200)
             .end(function (err, res) {
               if (err) return done(err);
-              s.expectMessage('express.response_code.GET_root.200:1|c', done);
+              s.expectMessage('express.response_code.200:1|c', done);
             });
         });
+
+        it('should count the response code with the url prefix', function (done) {
+          supertest(baseUrl)
+            .get('/')
+            .expect(200)
+            .end(function (err, res) {
+              if (err) return done(err);
+              s.expectMessage('express.response_code.GET_root.200:1|c', done);
+            })
+        })
 
         it('/ → "GET_root"', function (done) {
           supertest(baseUrl)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -103,8 +103,8 @@ describe('Helpers', function () {
             .end(function (err, res) {
               if (err) return done(err);
               s.expectMessage('express.response_code.GET_root.200:1|c', done);
-            })
-        })
+            });
+        });
 
         it('/ → "GET_root"', function (done) {
           supertest(baseUrl)


### PR DESCRIPTION
Per the discussion here: https://github.com/msiebuhr/node-statsd-client/commit/d78fca8ab9e3a0f4572f38a4aed303581e7050be

Adds back total status code counts along with per route counting.