### PR TITLE
Metric level tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ var timer = new Date();
 sdc.increment('some.counter'); // Increment by one.
 sdc.gauge('some.gauge', 10); // Set gauge to 10
 sdc.timing('some.timer', timer); // Calculates time diff
+sdc.histogram('some.histogram', 10, {foo: 'bar'}) // Histogram with tags
 
 sdc.close(); // Optional - stop NOW
 ```
@@ -117,6 +118,14 @@ statsd-extensions in a pinch.
 sdc.raw('foo.bar:123|t|@0.5|#key:value');
 ```
 
+### Tags
+
+All the methods above support metric level tags as their last argument. Just like global tags, the format for metric tags is an object of string key/value pairs.
+Tags at the metric level overwrite global tags with the same key.
+
+```javascript
+sdc.gauge('gauge.with.tags', 100, {foo: 'bar'});
+```
 
 ### Express helper
 

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -48,74 +48,77 @@ StatsDClient.prototype.getChildClient = function getChildClient(extraPrefix) {
 };
 
 /*
- * gauge(name, value)
+ * gauge(name, value, tags)
  */
-StatsDClient.prototype.gauge = function gauge(name, value) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|g" + this.formatTags());
+StatsDClient.prototype.gauge = function gauge(name, value, tags) {
+    this._socket.send(this.options.prefix + name + ":" + value + "|g" + this.formatTags(tags));
 
     return this;
 };
 
-StatsDClient.prototype.gaugeDelta = function gaugeDelta(name, delta) {
+/*
+ * gaugeDelta(name, delta, tags)
+ */
+StatsDClient.prototype.gaugeDelta = function gaugeDelta(name, delta, tags) {
     var sign = delta >= 0 ? "+" : "-";
-    this._socket.send(this.options.prefix + name + ":" + sign + Math.abs(delta) + "|g" + this.formatTags());
+    this._socket.send(this.options.prefix + name + ":" + sign + Math.abs(delta) + "|g" + this.formatTags(tags));
 
     return this;
 };
 
 /*
- * set(name, value)
+ * set(name, value, tags)
  */
-StatsDClient.prototype.set = function set(name, value) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|s" + this.formatTags());
+StatsDClient.prototype.set = function set(name, value, tags) {
+    this._socket.send(this.options.prefix + name + ":" + value + "|s" + this.formatTags(tags));
 
     return this;
 };
 
 /*
- * counter(name, delta)
+ * counter(name, delta, tags)
  */
-StatsDClient.prototype.counter = function counter(name, delta) {
-    this._socket.send(this.options.prefix + name + ":" + delta + "|c" + this.formatTags());
+StatsDClient.prototype.counter = function counter(name, delta, tags) {
+    this._socket.send(this.options.prefix + name + ":" + delta + "|c" + this.formatTags(tags));
 
     return this;
 };
 
 /*
- * increment(name, [delta=1])
+ * increment(name, [delta=1], tags)
  */
-StatsDClient.prototype.increment = function increment(name, delta) {
-    this.counter(name, Math.abs(delta === undefined ? 1 : delta));
+StatsDClient.prototype.increment = function increment(name, delta, tags) {
+    this.counter(name, Math.abs(delta === undefined ? 1 : delta), tags);
 
     return this;
 };
 
 /*
- * decrement(name, [delta=-1])
+ * decrement(name, [delta=-1], tags)
  */
-StatsDClient.prototype.decrement = function decrement(name, delta) {
-    this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta));
+StatsDClient.prototype.decrement = function decrement(name, delta, tags) {
+    this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta), tags);
 
     return this;
 };
 
 /*
- * timing(name, date-object | ms)
+ * timing(name, date-object | ms, tags)
  */
-StatsDClient.prototype.timing = function timing(name, time) {
+StatsDClient.prototype.timing = function timing(name, time, tags) {
     // Date-object or integer?
     var t = time instanceof Date ? new Date() - time : time;
 
-    this._socket.send(this.options.prefix + name + ":" + t + "|ms" + this.formatTags());
+    this._socket.send(this.options.prefix + name + ":" + t + "|ms" + this.formatTags(tags));
 
     return this;
 };
 
 /*
- * histogram(name, value)
+ * histogram(name, value, tags)
  */
-StatsDClient.prototype.histogram = function histogram(name, value) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|h" + this.formatTags());
+StatsDClient.prototype.histogram = function histogram(name, value, tags) {
+    this._socket.send(this.options.prefix + name + ":" + value + "|h" + this.formatTags(tags));
 
     return this;
 };
@@ -123,8 +126,8 @@ StatsDClient.prototype.histogram = function histogram(name, value) {
 /*
  * formatTags(tags)
  */
-StatsDClient.prototype.formatTags = function formatTags() {
-  var tags = this.options.tags;
+StatsDClient.prototype.formatTags = function formatTags(metric_tags) {
+  var tags = Object.assign({}, this.options.tags, metric_tags);
   if (!tags || Object.keys(tags).length === 0) {
     return '';
   }

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -127,7 +127,14 @@ StatsDClient.prototype.histogram = function histogram(name, value, tags) {
  * formatTags(tags)
  */
 StatsDClient.prototype.formatTags = function formatTags(metric_tags) {
-  var tags = Object.assign({}, this.options.tags, metric_tags);
+  var tags = {};
+
+  // Merge global tags and metric tags.
+  // Metric tags overwrite global tags for the same key.
+  var key;
+  for (key in this.options.tags) { tags[key] = this.options.tags[key]; }
+  for (key in metric_tags) { tags[key] = metric_tags[key]; }
+
   if (!tags || Object.keys(tags).length === 0) {
     return '';
   }

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -133,7 +133,7 @@ describe('StatsDClient', function () {
     });
 
     describe('Tags', function () {
-        it('.histogram("foo", 10) with tags {"test":"tag","other":"tag"} → "foo:10|h|#test:tag,other:tag"', function (done) {
+        it('.histogram("foo", 10) with global tags {"test":"tag","other":"tag"} → "foo:10|h|#test:tag,other:tag"', function (done) {
           new StatsDClient({
               maxBufferSize: 0,
               tags: {
@@ -142,6 +142,24 @@ describe('StatsDClient', function () {
               }
           }).histogram('foo', 10);
             s.expectMessage('foo:10|h|#test:tag,other:tag', done);
+        });
+
+        it('.histogram("foo", 10) with metric tags {"test":"tag","other":"tag"} → "foo:10|h|#test:tag,other:tag"', function (done) {
+          c.histogram('foo', 10, { test: 'tag', other: 'tag'});
+          s.expectMessage('foo:10|h|#test:tag,other:tag', done);
+        });
+
+        describe('metrics tags overwrite global tags', function () {
+          it('.gauge("foo", 10, {tags}) with global tags → "foo:10|g|#global:tag,other:metric,metric:tag"', function (done) {
+            new StatsDClient({
+              maxBufferSize: 0,
+              tags: {
+                global: 'tag',
+                other: 'tag'
+              }
+            }).gauge('foo', 10, {other: 'metric', metric: 'tag'});
+            s.expectMessage('foo:10|g|#global:tag,other:metric,metric:tag', done);
+          });
         });
     });
 


### PR DESCRIPTION
Follow up to https://github.com/msiebuhr/node-statsd-client/pull/69.

This adds a `tags` argument to all metric methods. In case of key collision with the global tags I decided to go with a metric level overwrite but that can be discussed (eg. if there's an `env` tag with different values at both the global and metric level we could send both instead of overwriting).

Happy to make changes if required.   