### PR TITLE
Support alternative tags formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Global options:
    it auto-closes the socket after this long without activity (default 1000 ms;
    0 disables this). For TCP, it auto-closes the socket after `socketTimeoutsToClose` number of timeouts have elapsed without activity.
  * `tags`: Object of string key/value pairs which will be appended on to all StatsD payloads (excluding raw payloads) (default `{}`)
+ * `influxdbTags: Boolean, if true the tags are formated in a form `name,tag1=a,tag2=b|value|ms`
+   rather than `name:value|ms|#tag1:a,tag2:b` (default false)`
 
 UDP options:
  * `host`: Where to send the stats (default `localhost`).

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -13,6 +13,8 @@ function StatsDClient(options) {
     // Set defaults
     this.options.prefix = this.options.prefix || "";
 
+    this.options.influxdbTags = this.options.influxdbTags || false;
+
     // Prefix?
     if (this.options.prefix && this.options.prefix !== "") {
         // Add trailing dot if it's missing
@@ -51,9 +53,7 @@ StatsDClient.prototype.getChildClient = function getChildClient(extraPrefix) {
  * gauge(name, value, tags)
  */
 StatsDClient.prototype.gauge = function gauge(name, value, tags) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|g" + this.formatTags(tags));
-
-    return this;
+    return this.send(name, value + "|g", tags);
 };
 
 /*
@@ -61,45 +61,36 @@ StatsDClient.prototype.gauge = function gauge(name, value, tags) {
  */
 StatsDClient.prototype.gaugeDelta = function gaugeDelta(name, delta, tags) {
     var sign = delta >= 0 ? "+" : "-";
-    this._socket.send(this.options.prefix + name + ":" + sign + Math.abs(delta) + "|g" + this.formatTags(tags));
 
-    return this;
+    return this.send(name, sign + Math.abs(delta) + "|g", tags);
 };
 
 /*
  * set(name, value, tags)
  */
 StatsDClient.prototype.set = function set(name, value, tags) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|s" + this.formatTags(tags));
-
-    return this;
+    return this.send(name, value + "|s", + tags);
 };
 
 /*
  * counter(name, delta, tags)
  */
 StatsDClient.prototype.counter = function counter(name, delta, tags) {
-    this._socket.send(this.options.prefix + name + ":" + delta + "|c" + this.formatTags(tags));
-
-    return this;
+    return this.send(name, delta + "|c", tags);
 };
 
 /*
  * increment(name, [delta=1], tags)
  */
 StatsDClient.prototype.increment = function increment(name, delta, tags) {
-    this.counter(name, Math.abs(delta === undefined ? 1 : delta), tags);
-
-    return this;
+    return this.counter(name, Math.abs(delta === undefined ? 1 : delta), tags);
 };
 
 /*
  * decrement(name, [delta=-1], tags)
  */
 StatsDClient.prototype.decrement = function decrement(name, delta, tags) {
-    this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta), tags);
-
-    return this;
+    return this.counter(name, -1 * Math.abs(delta === undefined ? 1 : delta), tags);
 };
 
 /*
@@ -109,18 +100,28 @@ StatsDClient.prototype.timing = function timing(name, time, tags) {
     // Date-object or integer?
     var t = time instanceof Date ? new Date() - time : time;
 
-    this._socket.send(this.options.prefix + name + ":" + t + "|ms" + this.formatTags(tags));
-
-    return this;
+    return this.send(name, t + "|ms", tags);
 };
 
 /*
  * histogram(name, value, tags)
  */
 StatsDClient.prototype.histogram = function histogram(name, value, tags) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|h" + this.formatTags(tags));
+    return this.send(name, value + "|h", tags);
+};
 
-    return this;
+/*
+ * send(name, formattedValue, tags)
+ */
+StatsDClient.prototype.send = function send(name, formattedValue, tags) {
+    var prefixedName = this.options.prefix + name;
+
+    if (this.options.influxdbTags) {
+        this._socket.send(prefixedName + this.formatInfluxdbTags(tags) + ":" + formattedValue);
+    } else {
+        this._socket.send(prefixedName + ":" + formattedValue + this.formatTags(tags));
+    }
+  return this;
 };
 
 /*
@@ -140,6 +141,27 @@ StatsDClient.prototype.formatTags = function formatTags(metric_tags) {
   }
   return '|#' + Object.keys(tags).map(function(key) {
     return key + ':' + tags[key];
+  }).join(',');
+};
+
+
+/*
+ * formatInfluxdbTags(tags)
+ */
+StatsDClient.prototype.formatInfluxdbTags = function formatInfluxdbTags(metric_tags) {
+  var tags = {};
+
+  // Merge global tags and metric tags.
+  // Metric tags overwrite global tags for the same key.
+  var key;
+  for (key in this.options.tags) { tags[key] = this.options.tags[key]; }
+  for (key in metric_tags) { tags[key] = metric_tags[key]; }
+
+  if (!tags || Object.keys(tags).length === 0) {
+    return '';
+  }
+  return ',' + Object.keys(tags).map(function(key) {
+    return key + '=' + tags[key];
   }).join(',');
 };
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "author": "Morten Siebuhr <sbhr@sbhr.dk>",
+  "author": "Mortencontributors Siebuhr <sbhr@sbhr.dk>",
+  "contributors": ["Nick Chistyakov <nick@6river.com>"],
   "name": "statsd-client",
   "description": "Yet another client for Etsy's statsd",
   "keywords": [
@@ -9,7 +10,7 @@
     "udp",
     "tcp"
   ],
-  "version": "0.4.0",
+  "version": "0.4.1",
   "homepage": "https://github.com/msiebuhr/node-statsd-client",
   "bugs": "https://github.com/msiebuhr/node-statsd-client/issues",
   "repository": {

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -161,6 +161,48 @@ describe('StatsDClient', function () {
             s.expectMessage('foo:10|g|#global:tag,other:metric,metric:tag', done);
           });
         });
+
+        context('with InfluxDB formatted tags', function() {
+          beforeEach(function() {
+            c.options.influxdbTags = true;
+          });
+
+          afterEach(function() {
+            c.options.influxdbTags = false;
+          });
+
+          it('.histogram("foo", 10) with global tags {"test":"tag","other":"tag"} → "foo,test=tag,other=tag:10|h"', function (done) {
+            new StatsDClient({
+                maxBufferSize: 0,
+                influxdbTags: true,
+                tags: {
+                  test: 'tag',
+                  other: 'tag'
+                }
+            }).histogram('foo', 10);
+              s.expectMessage('foo,test=tag,other=tag:10|h', done);
+          });
+
+          it('.histogram("foo", 10) with metric tags {"test":"tag","other":"tag"} → "foo,test=tag,other=tag:10|h"', function (done) {
+            c.histogram('foo', 10, { test: 'tag', other: 'tag'});
+            s.expectMessage('foo,test=tag,other=tag:10|h', done);
+          });
+
+          describe('metrics tags overwrite global tags', function () {
+            it('.gauge("foo", 10, {tags}) with global tags → "foo,global=tag,other=metric,metric=tag:10|g"', function (done) {
+              new StatsDClient({
+                maxBufferSize: 0,
+                influxdbTags: true,
+                tags: {
+                  global: 'tag',
+                  other: 'tag'
+                }
+              }).gauge('foo', 10, {other: 'metric', metric: 'tag'});
+              s.expectMessage('foo,global=tag,other=metric,metric=tag:10|g', done);
+            });
+          });
+        });
+
     });
 
     describe('Raw', function () {


### PR DESCRIPTION
This PR provides a configuration boolean flag `influxdbTags` setting which to `true` will format tags that InflusDB backend supports out of the box. Example:

```javascript
c.histogram("foo", 10, {"test":"tag","other":"tag"}) → "foo,test=tag,other=tag:10|h"
```