### PR TITLE
Add rate parameter for histogram and timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ And don't let the name (or nifty interface) fool you - it can measure any kind
 of number, where you want to see the distribution (content lengths, list items,
 query sizes, ...)
 
+Some implementations may require the rate to be explicitly sent for `timing`
+(and `histograms`). By default no rate is set, but custom values can be sent.
+It is the user's responsibility to control the actual rate.
+
+```javascript
+var start = new Date();
+sdc.timing('random.timeout', start, { tag: 'value' }, '@0.1');
+```
+
 ### Histogram
 
 Many implementations (though not the official one from Etsy) support

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -105,11 +105,12 @@ StatsDClient.prototype.decrement = function decrement(name, delta, tags) {
 /*
  * timing(name, date-object | ms, tags)
  */
-StatsDClient.prototype.timing = function timing(name, time, tags) {
+StatsDClient.prototype.timing = function timing(name, time, tags, rate) {
     // Date-object or integer?
     var t = time instanceof Date ? new Date() - time : time;
+    var r = typeof rate === 'string' && rate.indexOf('@') === 0 ? '|' + rate : '';
 
-    this._socket.send(this.options.prefix + name + ":" + t + "|ms" + this.formatTags(tags));
+    this._socket.send(this.options.prefix + name + ":" + t + "|ms" + r + this.formatTags(tags));
 
     return this;
 };
@@ -117,8 +118,10 @@ StatsDClient.prototype.timing = function timing(name, time, tags) {
 /*
  * histogram(name, value, tags)
  */
-StatsDClient.prototype.histogram = function histogram(name, value, tags) {
-    this._socket.send(this.options.prefix + name + ":" + value + "|h" + this.formatTags(tags));
+StatsDClient.prototype.histogram = function histogram(name, value, tags, rate) {
+    var r = typeof rate === 'string' && rate.indexOf('@') === 0 ? '|' + rate : '';
+
+    this._socket.send(this.options.prefix + name + ":" + value + "|h" + r + this.formatTags(tags));
 
     return this;
 };

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -102,6 +102,11 @@ describe('StatsDClient', function () {
             c.histogram('foo', 10);
             s.expectMessage('foo:10|h', done);
         });
+
+        it('.histogram("foo", 10, {}, "@0.1") ~→ "foo:10|h|@0.1"', function (done) {
+            c.histogram('foo', 10, {}, '@0.1');
+            s.expectMessage('foo:10|h|@0.1', done);
+        });
     });
 
     describe('Timers', function () {
@@ -129,6 +134,11 @@ describe('StatsDClient', function () {
                     s.expectMessage(sentMessages[0], done);
                 }, 10);
             }, 20);
+        });
+
+        it('.timing("foo", 10, {}, "@0.1") ~→ "foo:10|ms|@0.1"', function (done) {
+            c.timing('foo', 10, {}, '@0.1');
+            s.expectMessage('foo:10|ms|@0.1', done);
         });
     });
 


### PR DESCRIPTION
This Pull Request adds the ability to set rates for timing and histogram. 

In particular, Telegraf expects this measurements to have an explicit rate.