### PR TITLE
Add support for sub routers with parameterized routes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-    - "4"
     - "6"
     - "8"
     - "node"

--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -27,6 +27,7 @@ function findRouteName(req, res) {
 
         if (req.params) {
             Object.keys(req.params).forEach(function(key) {
+                if (req.params[key] === '') return;
                 routeName = routeName.replace(req.params[key], ':' + key);
             });
         }

--- a/lib/helpers/getExpressMiddleware.js
+++ b/lib/helpers/getExpressMiddleware.js
@@ -25,6 +25,12 @@ function findRouteName(req, res) {
             routeName = 'root';
         }
 
+        if (req.params) {
+            Object.keys(req.params).forEach(function(key) {
+                routeName = routeName.replace(req.params[key], ':' + key);
+            });
+        }
+
         // Appends the HTTP method
         return req.method + '_' + sanitize(routeName);
     }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -41,13 +41,17 @@ describe('Helpers', function () {
         });
 
         // Routes defined on the a subrouter or "micro-app".
-        var router = express.Router();
+        var router = express.Router({ mergeParams: true });
 
         router.get('/foo', function (req, res) {
             res.sendStatus(200);
         });
 
-        app.use('/subrouter', router);
+        router.get('/foo/:subparam', function (req, res) {
+            res.sendStatus(200);
+        });
+
+        app.use('/subrouter/:param', router);
 
         es = app.listen(3000, function () {
             baseUrl = 'http://localhost:' + 3000;
@@ -136,13 +140,23 @@ describe('Helpers', function () {
             });
 
             describe('sub-router', function () {
-                it('/subrouter/foo → "GET_subrouter_foo"', function (done) {
+                it('/subrouter/:param/foo → "GET_subrouter_param_foo"', function (done) {
                     supertest(baseUrl)
-                        .get('/subrouter/foo')
+                        .get('/subrouter/test/foo')
                         .expect(200)
                         .end(function (err/*, res*/) {
                             if (err) return done(err);
-                            s.expectMessage('express.response_time.GET_subrouter_foo:0|ms', done);
+                            s.expectMessage('express.response_time.GET_subrouter_param_foo:0|ms', done);
+                        });
+                });
+
+                it('/subrouter/:param/foo/:subparam → "GET_subrouter_param_foo_subparam"', function (done) {
+                    supertest(baseUrl)
+                        .get('/subrouter/test_param/foo/test_sub_param')
+                        .expect(200)
+                        .end(function (err/*, res*/) {
+                            if (err) return done(err);
+                            s.expectMessage('express.response_time.GET_subrouter_param_foo_subparam:0|ms', done);
                         });
                 });
             });


### PR DESCRIPTION
Previously, when using a sub router on a parameterized route like
`app.use('/foo/:param', router)`, `findRouteName` would not correctly
resolve the route parameter for the parent route. This happened because
`req.baseUrl` contained the url with the value, not the parameter. To
solve this, this PR adds code to translate from the url with the value,
back to the parameterized version (i.e. `/foo/value -> /foo/:param`).