### PR TITLE
feat(distribution): add support for datadog's distribution metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ sdc.increment('some.counter'); // Increment by one.
 sdc.gauge('some.gauge', 10); // Set gauge to 10
 sdc.timing('some.timer', timer); // Calculates time diff
 sdc.histogram('some.histogram', 10, {foo: 'bar'}) // Histogram with tags
+sdc.distribution('some.distribution', 10, {foo: 'bar'}) // Distribution with tags
 
 sdc.close(); // Optional - stop NOW
 ```
@@ -110,6 +111,11 @@ Many implementations (though not the official one from Etsy) support
 histograms as an alias/alternative for timers. So aside from the fancy bits
 with handling dates, this is much the same as `.timing()`.
 
+### Distribution
+
+Datadog's specific implementation supports another extra alternative to timers,
+called the [distribution metric type](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types)
+this is pretty much an alias to histograms and can be used via `.distribution()`.
 
 ### Raw
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ with handling dates, this is much the same as `.timing()`.
 
 ### Distribution
 
-Datadog's specific implementation supports another extra alternative to timers,
-called the [distribution metric type](https://docs.datadoghq.com/developers/metrics/types/?tab=distribution#metric-types)
-this is pretty much an alias to histograms and can be used via `.distribution()`.
+Datadog's specific implementation supports another alternative to timers/histograms,
+called the [distribution metric type](https://docs.datadoghq.com/metrics/distributions/).
+From the client's perspective, this is pretty much an alias to histograms and can be used via `.distribution()`.
 
 ### Raw
 

--- a/lib/statsd-client.js
+++ b/lib/statsd-client.js
@@ -124,6 +124,15 @@ StatsDClient.prototype.histogram = function histogram(name, value, tags) {
 };
 
 /*
+ * distribution(name, value, tags)
+ */
+StatsDClient.prototype.distribution = function distribution(name, value, tags) {
+    this._socket.send(this.options.prefix + name + ":" + value + "|d" + this.formatTags(tags));
+
+    return this;
+};
+
+/*
  * formatTags(tags)
  */
 StatsDClient.prototype.formatTags = function formatTags(metric_tags) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "url": "git://github.com/msiebuhr/node-statsd-client.git"
   },
   "main": "lib/statsd-client.js",
-  "dependencies": {},
   "devDependencies": {
     "chai": "~1.3.0",
     "eslint": "^4.16.0",

--- a/test/StatsDClient.js
+++ b/test/StatsDClient.js
@@ -104,6 +104,13 @@ describe('StatsDClient', function () {
         });
     });
 
+    describe('Distributions', function () {
+        it('.distribution("foo", 10) → "foo:10|d', function (done) {
+            c.distribution('foo', 10);
+            s.expectMessage('foo:10|d', done);
+        });
+    });
+
     describe('Timers', function () {
         it('.timing("foo", 10) → "foo:10|ms', function (done) {
             c.timing('foo', 10);
@@ -147,6 +154,22 @@ describe('StatsDClient', function () {
         it('.histogram("foo", 10) with metric tags {"test":"tag","other":"tag"} → "foo:10|h|#test:tag,other:tag"', function (done) {
             c.histogram('foo', 10, { test: 'tag', other: 'tag'});
             s.expectMessage('foo:10|h|#test:tag,other:tag', done);
+        });
+
+        it('.distribution("foo", 10) with global tags {"test":"tag","other":"tag"} → "foo:10|d|#test:tag,other:tag"', function (done) {
+            new StatsDClient({
+                maxBufferSize: 0,
+                tags: {
+                    test: 'tag',
+                    other: 'tag'
+                }
+            }).distribution('foo', 10);
+            s.expectMessage('foo:10|d|#test:tag,other:tag', done);
+        });
+
+        it('.distribution("foo", 10) with metric tags {"test":"tag","other":"tag"} → "foo:10|d|#test:tag,other:tag"', function (done) {
+            c.distribution('foo', 10, { test: 'tag', other: 'tag'});
+            s.expectMessage('foo:10|d|#test:tag,other:tag', done);
         });
 
         describe('metrics tags overwrite global tags', function () {
@@ -201,6 +224,10 @@ describe('StatsDClient', function () {
 
         it('.histogram() chains', function() {
             assert.equal(c, c.histogram('x', 'y'));
+        });
+
+        it('.distribution() chains', function() {
+            assert.equal(c, c.distribution('x', 'y'));
         });
 
         it('.raw() chains', function () {


### PR DESCRIPTION
Hey there 👋 

As part of https://github.com/netlify/build/issues/2784 we're working on forwarding [`distribution` metrics](https://docs.datadoghq.com/metrics/distributions/) to our backend of choice, Datadog. I've put together this PR that adds support for it. This is essentially an `histogram` metric with a different type that instructs the agent not to pre-agregate data and to forward it as-is to the backend. I understand this is a [DogStatsd specific metric type](https://github.com/DataDog/datadog-go/blob/v4.7.0/statsd/statsd.go#L154-L155), not part of the `statsd` spec and as such might be something you're not really insterested in supporting (and we can always rely on the `raw` method). That being said, it's a fairly simple set of changes that we'll also need on our side so thought I would submit this PR 👍 let me know if anything's missing.

And thanks for this awesome lib!